### PR TITLE
Propagate options through operations

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -12,10 +12,11 @@ require "vector_number"
 
 V0 = VectorNumber[0]
 V1 = VectorNumber[1]
-Vi = VectorNumber[1.i]
+Vi = VectorNumber[1i]
 Va = VectorNumber["a"]
 Vs = VectorNumber[:s]
 Vpi = VectorNumber[:pi] * Math::PI
+Vopt = VectorNumber[8, mult: :invisible]
 
 require "irb"
 IRB.start(__FILE__)

--- a/lib/vector_number/stringifying.rb
+++ b/lib/vector_number/stringifying.rb
@@ -36,6 +36,7 @@ class VectorNumber
 
     # @return [String]
     def inspect
+      # TODO: Probably make this independent of options.
       "(#{self})"
     end
 

--- a/sig/vector_number.rbs
+++ b/sig/vector_number.rbs
@@ -51,7 +51,7 @@ class VectorNumber
   def self.[]: (*unit_type values, **options_type options) -> vector_type
 
   def initialize:
-    (?(units_list_type | plain_vector_type | vector_type)? values, ?options_type options)
+    (?(units_list_type | plain_vector_type | vector_type)? values, ?options_type? options)
     ?{ (coefficient_type coefficient) -> coefficient_type }
     -> void
 

--- a/spec/vector_number/mathing_spec.rb
+++ b/spec/vector_number/mathing_spec.rb
@@ -92,12 +92,8 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       let(:other) { [rand(1.0..2.0), rand(1..10_000), rand(1r..100r)].sample }
       let(:result_array) do
         values = number.to_a
-        if (value = values.assoc(VectorNumber::R))
-          value[1] += other.real
-        else
-          values << [VectorNumber::R, other.real]
-        end
-        values
+        values.delete(values.assoc(VectorNumber::R))
+        values << [VectorNumber::R, number.real + other.real]
       end
 
       it "creates a new number, adding real number to real part" do
@@ -121,12 +117,8 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       let(:other) { [rand(1.0..2.0), rand(1..10_000), rand(1r..100r)].sample }
       let(:result_array) do
         values = number.to_a
-        if (value = values.assoc(VectorNumber::R))
-          value[1] += other.real
-        else
-          values << [VectorNumber::R, other.real]
-        end
-        values
+        values.delete(values.assoc(VectorNumber::R))
+        values << [VectorNumber::R, number.real + other.real]
       end
 
       it "creates a new number, adding real number to real part" do
@@ -148,17 +140,10 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       let(:other) { Complex(rand(-1000..-8), rand(10.0..1000.0)) }
       let(:result_array) do
         values = number.to_a
-        if (value = values.assoc(VectorNumber::R))
-          value[1] += other.real
-        else
-          values << [VectorNumber::R, other.real]
-        end
-        if (value = values.assoc(VectorNumber::I))
-          value[1] += other.imag
-        else
-          values << [VectorNumber::I, other.imag]
-        end
-        values
+        values.delete(values.assoc(VectorNumber::R))
+        values.delete(values.assoc(VectorNumber::I))
+        values << [VectorNumber::R, number.real + other.real]
+        values << [VectorNumber::I, number.imag + other.imag]
       end
 
       it "creates a new number, adding real part and imaginary parts together correspondingly" do
@@ -173,17 +158,10 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       let(:other) { Complex(rand(-1000..-8), rand(10.0..1000.0)) }
       let(:result_array) do
         values = number.to_a
-        if (value = values.assoc(VectorNumber::R))
-          value[1] += other.real
-        else
-          values << [VectorNumber::R, other.real]
-        end
-        if (value = values.assoc(VectorNumber::I))
-          value[1] += other.imag
-        else
-          values << [VectorNumber::I, other.imag]
-        end
-        values
+        values.delete(values.assoc(VectorNumber::R))
+        values.delete(values.assoc(VectorNumber::I))
+        values << [VectorNumber::R, number.real + other.real]
+        values << [VectorNumber::I, number.imag + other.imag]
       end
 
       it "creates a new number, adding real part and imaginary parts together correspondingly" do
@@ -249,12 +227,8 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       let(:other) { [rand(6.0..7.0), rand(13..10_000), rand(10r..100r)].sample }
       let(:result_array) do
         values = number.to_a
-        if (value = values.assoc(VectorNumber::R))
-          value[1] -= other.real
-        else
-          values << [VectorNumber::R, -other.real]
-        end
-        values
+        values.delete(values.assoc(VectorNumber::R))
+        values << [VectorNumber::R, number.real - other.real]
       end
 
       it "creates a new number, subtracting real number from real part" do
@@ -278,11 +252,8 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       let(:other) { [rand(6.0..7.0), rand(13..10_000), rand(10r..100r)].sample }
       let(:result_array) do
         values = number.to_a
-        if (value = values.assoc(VectorNumber::R))
-          value[1] -= other.real
-        else
-          values << [VectorNumber::R, -other.real]
-        end
+        values.delete(values.assoc(VectorNumber::R))
+        values << [VectorNumber::R, number.real - other.real]
         values.map { |u, c| [u, -c] }
       end
 
@@ -305,17 +276,10 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       let(:other) { Complex(rand(31..32), rand(0.5..555.5)) }
       let(:result_array) do
         values = number.to_a
-        if (value = values.assoc(VectorNumber::R))
-          value[1] -= other.real
-        else
-          values << [VectorNumber::R, -other.real]
-        end
-        if (value = values.assoc(VectorNumber::I))
-          value[1] -= other.imag
-        else
-          values << [VectorNumber::I, -other.imag]
-        end
-        values
+        values.delete(values.assoc(VectorNumber::R))
+        values.delete(values.assoc(VectorNumber::I))
+        values << [VectorNumber::R, number.real - other.real]
+        values << [VectorNumber::I, number.imag - other.imag]
       end
 
       it "creates a new number, subtracting real and imaginary parts correspondingly" do
@@ -330,16 +294,10 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       let(:other) { Complex(rand(31..32), rand(0.5..555.5)) }
       let(:result_array) do
         values = number.to_a
-        if (value = values.assoc(VectorNumber::R))
-          value[1] -= other.real
-        else
-          values << [VectorNumber::R, -other.real]
-        end
-        if (value = values.assoc(VectorNumber::I))
-          value[1] -= other.imag
-        else
-          values << [VectorNumber::I, -other.imag]
-        end
+        values.delete(values.assoc(VectorNumber::R))
+        values.delete(values.assoc(VectorNumber::I))
+        values << [VectorNumber::R, number.real - other.real]
+        values << [VectorNumber::I, number.imag - other.imag]
         values.map { |u, c| [u, -c] }
       end
 

--- a/spec/vector_number/mathing_spec.rb
+++ b/spec/vector_number/mathing_spec.rb
@@ -17,7 +17,28 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       it "returns array with other value and self unchanged" do
         # This expectation depends on Comparing#==.
         expect(result).to eq [other, number]
+        # Check that these are actually the same objects, not just equal ones.
         expect(result.first).to be other
+        expect(result.last).to be number
+      end
+    end
+
+    context "when other value is a number" do
+      let(:other) { [5, 55.55, 5/55r].sample }
+
+      it "returns array with vectorized other value and self" do
+        expect(result).to eq [num(other), number]
+        expect(result.first.units).to eq [VectorNumber::R]
+      end
+    end
+
+    context "when other value is NaN" do
+      let(:other) { Float::NAN }
+
+      it "returns array with vectorized NaN and self" do
+        # NaN is not equal to NaN.
+        expect(result.first.units).to eq [VectorNumber::R]
+        expect(result.first.coefficients.first).to be_nan
         expect(result.last).to be number
       end
     end
@@ -40,22 +61,47 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
       end
     end
 
-    context "when other value is anything else" do
-      let(:other) { [Object.new, [1], "myself", Float::DIG].sample }
+    context "when other value is whatever else" do
+      let(:other) { [Object.new, "myself", :vector, 1.upto(2)].sample }
 
       it "returns array with vectorized other value and self" do
         expect(result).to eq [num(other), number]
+        expect(result.first.units).to eq [other]
       end
     end
 
-    context "when other value is NaN" do
-      let(:other) { [Float::NAN].sample }
+    context "if number has non-default options" do
+      let(:number) { num(rand, rand.i, "coerce", mult: :cross) }
 
-      it "returns array with vectorized NaN and self" do
-        # NaN is not equal to NaN.
-        expect(result.first.units.first).to be VectorNumber::R
-        expect(result.first.coefficients.first).to be_nan
-        expect(result.last).to be number
+      context "when other value is a VectorNumber" do
+        let(:other) { num(rand, mult: :blank) }
+
+        it "leaves options as-is for both" do
+          expect(result.first.options).to eq(mult: :blank)
+          expect(result.last.options).to eq(mult: :cross)
+        end
+      end
+
+      context "when other value is anything else" do
+        let(:other) { [-33, Object.new, "myself", :vector, 1.upto(2)].sample }
+
+        it "propagates options to the new vector" do
+          expect(result.first.options).to eq(mult: :cross)
+          expect(result.last.options).to eq(mult: :cross)
+        end
+      end
+    end
+  end
+
+  shared_examples "options propagation" do
+    context "when number has non-default options" do
+      let(:number) { num(rand.i, mult: "mult") }
+      let(:other) { num(rand * rand, mult: "ult") }
+
+      it "propagates first vector's options to the result" do
+        # `eq` would be mostly sufficient,
+        # but we also optimize options to be the same hash.
+        expect(result.options).to be number.options
       end
     end
   end
@@ -75,6 +121,8 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
 
     let(:number) { [zero_number, real_number, composite_number, f_number].sample }
 
+    include_examples "options propagation"
+
     it "returns a new number with all coefficients negated" do
       expect(result.units).to eq number.units
       expect(result.coefficients).to eq number.coefficients.map(&:-@)
@@ -87,6 +135,8 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
     subject(:result) { number + other }
 
     let(:number) { [zero_number, real_number, composite_number, f_number].sample }
+
+    include_examples "options propagation"
 
     context "when adding a real number" do
       let(:other) { [rand(1.0..2.0), rand(1..10_000), rand(1r..100r)].sample }
@@ -222,6 +272,8 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
     subject(:result) { number - other }
 
     let(:number) { [zero_number, real_number, composite_number, f_number].sample }
+
+    include_examples "options propagation"
 
     context "when subtracting a real number" do
       let(:other) { [rand(6.0..7.0), rand(13..10_000), rand(10r..100r)].sample }
@@ -367,6 +419,8 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
 
     let(:number) { [zero_number, real_number, composite_number, f_number].sample }
 
+    include_examples "options propagation"
+
     context "when multiplying by a real number" do
       let(:other) { [-rand(6.0..7.0), rand(13..10_000), rand(10r..100r)].sample }
 
@@ -508,6 +562,9 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
 
     let(:number) { [zero_number, real_number, composite_number, f_number].sample }
 
+    include_examples "options propagation"
+    include_examples "invalid division"
+
     context "when dividing by a real number" do
       let(:other) { [-rand(6.0..7.0), rand(10r..100r)].sample }
 
@@ -597,8 +654,6 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
         end
       end
     end
-
-    include_examples "invalid division"
   end
 
   include_examples "has an alias", :quo, :/
@@ -607,6 +662,9 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
     subject(:result) { number.fdiv(other) }
 
     let(:number) { [zero_number, real_number, composite_number, f_number].sample }
+
+    include_examples "options propagation"
+    include_examples "invalid division"
 
     context "when dividing by a real number" do
       let(:other) { [-rand(6.0..7.0), rand(10r..100r)].sample }
@@ -760,8 +818,6 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
         end
       end
     end
-
-    include_examples "invalid division"
   end
 
   describe "#div" do
@@ -769,6 +825,9 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
 
     let(:number) { num(32.14, -123.45i, 128r / 9, :a, :a) }
     let(:other) { rand(-10.0..10.0) }
+
+    include_examples "options propagation"
+    include_examples "invalid division"
 
     it "calls #div on each component" do
       expect(result.to_a).to match_array([
@@ -825,8 +884,6 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
         expect(result).to eq number.div(value)
       end
     end
-
-    include_examples "invalid division"
   end
 
   describe "#%" do
@@ -834,6 +891,9 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
 
     let(:number) { num(1.5, -1i, "sshshs", :a, :a) * -3.5 }
     let(:other) { rand(-10.0..10.0) }
+
+    include_examples "options propagation"
+    include_examples "invalid division"
 
     it "calls #% on each component" do
       expect(result.to_a).to match_array([
@@ -892,8 +952,6 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
         expect(result).to eq number % value
       end
     end
-
-    include_examples "invalid division"
   end
 
   include_examples "has an alias", :modulo, :%
@@ -904,11 +962,11 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
     let(:number) { [zero_number, real_number, composite_number, f_number].sample }
     let(:other) { rand(-10.0..10.0) }
 
+    include_examples "invalid division"
+
     it "returns a tuple of #div and #% results" do
       expect(result).to eq [number.div(other), number % other]
     end
-
-    include_examples "invalid division"
   end
 
   describe "#remainder" do
@@ -916,6 +974,9 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
 
     let(:number) { num(1.5, -1i, "sshshs", :a, :a) * -3.5 }
     let(:other) { rand(-10.0..10.0) }
+
+    include_examples "options propagation"
+    include_examples "invalid division"
 
     it "calls #% on each component" do
       expect(result.to_a).to match_array([
@@ -974,7 +1035,5 @@ RSpec.describe VectorNumber::Mathing, :aggregate_failures do
         expect(result).to eq number.remainder(value)
       end
     end
-
-    include_examples "invalid division"
   end
 end

--- a/spec/vector_number/new_spec.rb
+++ b/spec/vector_number/new_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe VectorNumber, ".new", :aggregate_failures do
     end
   end
 
+  context "when initializing with a vector number" do
+    let(:value) { num("you", "are", "cute") }
+
+    it "copies values and options from it" do
+      expect(new_number).to be_a described_class
+      expect(new_number).to be_frozen
+      expect(new_number.to_a).to contain_exactly ["you", 1], ["are", 1], ["cute", 1]
+      expect(new_number.options).to be value.options
+    end
+  end
+
   context "when initializing with an array" do
     let(:value) { [1, 0.25r, 2.5ri, "a", "a", :a, 0, -0.5, Complex(1, 2)] }
 
@@ -55,16 +66,15 @@ RSpec.describe VectorNumber, ".new", :aggregate_failures do
         expect(new_number).to eql num(18.25, 4.1i, "s", "s")
       end
     end
-  end
 
-  context "when initializing with a vector number" do
-    let(:value) { num("you", "are", "cute") }
+    context "when array contains vector numbers with options" do
+      let(:value) { [0.25r, num(15r, Complex(3, 4.1), "s", mult: :cross), num("s", mult: "blank")] }
 
-    it "copies values and options from it" do
-      expect(new_number).to be_a described_class
-      expect(new_number).to be_frozen
-      expect(new_number.to_a).to contain_exactly ["you", 1], ["are", 1], ["cute", 1]
-      expect(new_number.options).to eq value.options
+      it "copies options from the first vector encountered" do
+        expect(new_number.size).to eq 3
+        expect(new_number).to eql num(18.25, 4.1i, "s", "s")
+        expect(new_number.options).to eq({ mult: :cross })
+      end
     end
   end
 

--- a/spec/vector_number/stringifying_spec.rb
+++ b/spec/vector_number/stringifying_spec.rb
@@ -72,6 +72,29 @@ RSpec.describe VectorNumber::Stringifying do
         end
       end
     end
+
+    context "when :mult option is passed to the constructor" do
+      subject(:string) { number.to_s }
+
+      let(:number) { num("y", :a, 5, 3, "y", mult: "!") }
+
+      context "when :mult option is not passed to #to_s" do
+        it "inserts multiplication symbol specified for the number" do
+          expect(string).to eq "2!'y' + 1!a + 8"
+        end
+      end
+
+      context "when :mult option is also passed to #to_s" do
+        subject(:string) { number.to_s(mult: mult) }
+
+        let(:mult) { described_class::MULT_STRINGS.keys.sample }
+        let(:char) { described_class::MULT_STRINGS[mult] }
+
+        it "inserts multiplication symbol passed in the call" do
+          expect(string).to eq "2#{char}'y' + 1#{char}a + 8"
+        end
+      end
+    end
   end
 
   describe "#inspect" do


### PR DESCRIPTION
Previously, options were propagated only in very specific conditions, most of the time they had to be specified manually, making a copy of a vector. Now, options should propagate in all cases, except when several vectors with different options are present — only one's options will be used.