### PR TITLE
Improve links in gemspec, add latest version badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Next]
+
+**Changed**
+- Improve gemspec:
+  - change source code and changelog links to point to a tagged commit;
+  - add bugtracker and documentation links;
+  - properly add CHANGELOG.md to doc generation.
+
+**Fixed**
+- Correct broken changelog link in gem metadata.
+
 ## [v0.3.0] — 2025-05-12
 
 **Added**
@@ -18,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    When creating new vector through any operation, participating vector's options
    are copied to the new one. When several vectors are present, only first one matters.
 - Both `#+@` and `#dup` are now aliases of `#itself` instead of full methods.
-- [🚀 CI] Refactor workflows to reduce duplication.
+- [🚀 CI] "CI" workflow now reports status of all checks,
+   excluding allowed-to-fail workflows (currently JRuby and TruffleRuby).
 
 ## [v0.2.6] — 2025-04-30
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # VectorNumber
 
+Latest: [![Gem Version](https://badge.fury.io/rb/vector_number.svg?icon=si%3Arubygems)](https://badge.fury.io/rb/vector_number)
 [![CI](https://github.com/trinistr/vector_number/actions/workflows/CI.yaml/badge.svg)](https://github.com/trinistr/vector_number/actions/workflows/CI.yaml)
 
 A library to add together anything: be it a number, string or random Object, it can be added together in an infinite-dimensional vector space, with math operations available on results.

--- a/vector_number.gemspec
+++ b/vector_number.gemspec
@@ -13,8 +13,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/CHANGELOG.md"
+  spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
+  spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/vector_number/#{VectorNumber::VERSION}"
+  spec.metadata["source_code_uri"] = "#{spec.homepage}/tree/v#{VectorNumber::VERSION}"
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/v#{VectorNumber::VERSION}/CHANGELOG.md"
+
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir["{lib,sig,exe}/**/*"].select { File.file?(_1) }
@@ -22,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
 
   spec.extra_rdoc_files = ["README.md", "CHANGELOG.md"]
-  spec.rdoc_options << "--main" << "README.md"
+  spec.rdoc_options << "--main" << "README.md" << "--files" << "CHANGELOG.md"
 end


### PR DESCRIPTION
- Broken link to changelog now correctly points to the blob.
- Documentation and source code links now point to versioned instances.
- Changelog is now actually added to documentation

Separated from #9