### PR TITLE
Optimize various initialization paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Next]
 
 **Changed**
-- [🍄 BREAKING] `R` and `I` constants are now `1` and `2` instead of `0i` and `1i` respectively.
+- [🍄 BREAKING] Change `R` and `I` constants to be `1` and `2` instead of `0i` and `1i` respectively.
    Their values are still semi-private and should not be relied on.
 - [🍄 BREAKING] Calling `new` with an unsupported value now raises `ArgumentError` instead of treating it like air.
+- Optimize various initialization paths. It is now 1.5-2.5 times faster, depending on arguments.
 
 [Compare v0.3.1...main](https://github.com/trinistr/vector_number/compare/v0.3.1...main)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+**Changed**
+- [Breaking] Calling `new` with an unsupported value now raises `ArgumentError` instead of treating it like air.
+
 [Compare v0.3.1...main](https://github.com/trinistr/vector_number/compare/v0.3.1...main)
 
 ## [v0.3.1] — 2025-06-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Next]
 
 **Changed**
-- [Breaking] Calling `new` with an unsupported value now raises `ArgumentError` instead of treating it like air.
+- [🍄 BREAKING] `R` and `I` constants are now `1` and `2` instead of `0i` and `1i` respectively.
+   Their values are still semi-private and should not be relied on.
+- [🍄 BREAKING] Calling `new` with an unsupported value now raises `ArgumentError` instead of treating it like air.
 
 [Compare v0.3.1...main](https://github.com/trinistr/vector_number/compare/v0.3.1...main)
 
@@ -39,7 +41,7 @@ This is mostly a documentation update with a side of improved gemspec.
    `#+@` was already practically aliased by `#dup`.
 
 **Changed**
-- [Breaking] Long-existing but broken options feature is now fixed.
+- [🍄 BREAKING] Long-existing but broken options feature is now fixed.
    When creating new vector through any operation, participating vector's options
    are copied to the new one. When several vectors are present, only first one matters.
 - Both `#+@` and `#dup` are now aliases of `#itself` instead of full methods.
@@ -76,7 +78,7 @@ README was updated to reflect this change.
 - Add hash-like methods `#[]` and `#unit?` (aliased as `#key?`).
 
 **Changed**
-- [Breaking] Change `positive?` and `negative?` to no longer return `nil`
+- [🍄 BREAKING] Change `positive?` and `negative?` to no longer return `nil`
    when number is neither strictly positive or negative,
    these cases will now return `false`.
 - Make `VectorNumber.new` accept options when initializing from a VectorNumber

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,12 @@ gemspec
 # For running checks
 gem "rake", "~> 13.0", require: false
 
-# Testing
+# Testing framework
 gem "rspec", "~> 3.0", require: false
+
+# Benchmarking performance
+gem "benchmark", require: false
+gem "benchmark-ips", require: false
 
 group :linting do
   # Linting

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,6 @@ gem "rake", "~> 13.0", require: false
 # Testing framework
 gem "rspec", "~> 3.0", require: false
 
-# Benchmarking performance
-gem "benchmark", require: false
-gem "benchmark-ips", require: false
-
 group :linting do
   # Linting
   gem "rubocop", "~> 1.72", require: false
@@ -48,4 +44,9 @@ group :development do
 
   # Version changes
   gem "bump", require: false
+
+  # Benchmarking performance
+  gem "benchmark", require: false
+  gem "benchmark-ips", require: false
+  gem "stackprof", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
       yard-solargraph (~> 0.1)
+    stackprof (0.2.27)
     steep (1.10.0)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
@@ -235,6 +236,7 @@ DEPENDENCIES
   rubocop-yard
   simplecov
   solargraph
+  stackprof
   steep
   vector_number!
   yard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
     backport (1.2.0)
     base64 (0.3.0)
     benchmark (0.4.1)
+    benchmark-ips (2.14.0)
     bigdecimal (3.2.2)
     bump (0.10.0)
     concurrent-ruby (1.3.5)
@@ -218,6 +219,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  benchmark
+  benchmark-ips
   bigdecimal
   bump
   rake (~> 13.0)

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ VectorNumbers are mostly useful for summing up heterogeneous objects:
 sum = VectorNumber[]
 [4, "death", "death", 13, nil].each { sum = sum + _1 }
 sum # => (17 + 2⋅'death' + 1⋅)
-sum.to_a # => [[(0+0i), 17], ["death", 2], [nil, 1]]
-sum.to_h # => {(0+0i)=>17, "death"=>2, nil=>1}
+sum.to_a # => [[1, 17], ["death", 2], [nil, 1]]
+sum.to_h # => {1=>17, "death"=>2, nil=>1}
 ```
 
 Alternatively, the same result can be equivalently (and more efficiently) achieved by

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Bundler
+require "bundler/setup"
+
+# Supporting libraries.
+require "bigdecimal/util"
+require "fileutils"
+
+require "benchmark"
+require "benchmark/ips"
+require "stackprof"
+
+# This gem.
+require "vector_number"
+
+V0 = VectorNumber[0]
+V1 = VectorNumber[1]
+Vi = VectorNumber[1i]
+Va = VectorNumber["a"]
+Vs = VectorNumber[:s]
+Vpi = VectorNumber[:pi] * Math::PI
+Vopt = VectorNumber[8, mult: :invisible]
+# ((V1 * 3.3) + (Va * 4.5) - Vs)
+V = VectorNumber[3.3] + (4.5 * VectorNumber["a"]) - VectorNumber[:s]
+
+FileUtils.mkdir_p("tmp")
+StackProf.run(mode: :cpu, raw: true, out: "tmp/stackprof.dump") do
+  Benchmark.ips do |ips|
+    ips.report("real") { VectorNumber[1_345.34, -123.45, Complex(1, 0), 123.45r] }
+    ips.report("real-real") { VectorNumber[1_345.34, -123.45, 1, 123.45r] }
+    ips.report("complex") { VectorNumber[1_345.34i, Complex(12, -4556.2), Complex(0, 123.45), 15r] }
+    ips.report("string/symbol") { VectorNumber["asdf", "sdnhsdughdfghkdfg", :asdsafsdf, "asdf"] }
+    ips.report("from vector []") { VectorNumber[V] }
+    ips.report("from vector new") { VectorNumber.new(V) }
+    ips.report("-@") { -V }
+    ips.report("* 3") { V * 3 }
+    ips.report("various (+)") { VectorNumber[Complex(12, -4556.2), V, "asdf", :asdsafsdf, "asdf"] }
+  end
+end
+
+`stackprof tmp/stackprof.dump  --d3-flamegraph > tmp/flamegraph.html`
+
+# Baseline:
+#                 real    120.248k (± 6.7%) i/s    (8.32 μs/i) -    600.984k in   5.026862s
+#            real-real    123.672k (± 6.2%) i/s    (8.09 μs/i) -    616.224k in   5.006814s
+#              complex    118.893k (± 4.8%) i/s    (8.41 μs/i) -    597.450k in   5.039148s
+#        string/symbol    273.629k (± 6.4%) i/s    (3.65 μs/i) -      1.373M in   5.042627s
+#       from vector []    289.128k (± 6.4%) i/s    (3.46 μs/i) -      1.463M in   5.085560s
+#      from vector new    379.761k (± 6.6%) i/s    (2.63 μs/i) -      1.891M in   5.010302s
+#                   -@    235.569k (± 6.8%) i/s    (4.25 μs/i) -      1.192M in   5.088220s
+#                  * 3    248.626k (± 6.2%) i/s    (4.02 μs/i) -      1.260M in   5.097549s
+#          various (+)    165.008k (± 4.9%) i/s    (6.06 μs/i) -    831.630k in   5.054346s

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -43,12 +43,23 @@ end
 `stackprof tmp/stackprof.dump  --d3-flamegraph > tmp/flamegraph.html`
 
 # Baseline:
-#                 real    120.248k (± 6.7%) i/s    (8.32 μs/i) -    600.984k in   5.026862s
-#            real-real    123.672k (± 6.2%) i/s    (8.09 μs/i) -    616.224k in   5.006814s
-#              complex    118.893k (± 4.8%) i/s    (8.41 μs/i) -    597.450k in   5.039148s
-#        string/symbol    273.629k (± 6.4%) i/s    (3.65 μs/i) -      1.373M in   5.042627s
-#       from vector []    289.128k (± 6.4%) i/s    (3.46 μs/i) -      1.463M in   5.085560s
-#      from vector new    379.761k (± 6.6%) i/s    (2.63 μs/i) -      1.891M in   5.010302s
-#                   -@    235.569k (± 6.8%) i/s    (4.25 μs/i) -      1.192M in   5.088220s
-#                  * 3    248.626k (± 6.2%) i/s    (4.02 μs/i) -      1.260M in   5.097549s
-#          various (+)    165.008k (± 4.9%) i/s    (6.06 μs/i) -    831.630k in   5.054346s
+#             real    120.248k (± 6.7%) i/s    (8.32 μs/i) -    600.984k in   5.026862s
+#        real-real    123.672k (± 6.2%) i/s    (8.09 μs/i) -    616.224k in   5.006814s
+#          complex    118.893k (± 4.8%) i/s    (8.41 μs/i) -    597.450k in   5.039148s
+#    string/symbol    273.629k (± 6.4%) i/s    (3.65 μs/i) -      1.373M in   5.042627s
+#   from vector []    289.128k (± 6.4%) i/s    (3.46 μs/i) -      1.463M in   5.085560s
+#  from vector new    379.761k (± 6.6%) i/s    (2.63 μs/i) -      1.891M in   5.010302s
+#               -@    235.569k (± 6.8%) i/s    (4.25 μs/i) -      1.192M in   5.088220s
+#              * 3    248.626k (± 6.2%) i/s    (4.02 μs/i) -      1.260M in   5.097549s
+#      various (+)    165.008k (± 4.9%) i/s    (6.06 μs/i) -    831.630k in   5.054346s
+
+# After optimization of init paths (#13):
+#             real    289.522k (± 3.4%) i/s    (3.45 μs/i) -      1.453M in   5.024349s
+#        real-real    329.834k (± 2.6%) i/s    (3.03 μs/i) -      1.666M in   5.054816s
+#          complex    268.877k (± 4.9%) i/s    (3.72 μs/i) -      1.358M in   5.067001s
+#    string/symbol    383.751k (± 3.3%) i/s    (2.61 μs/i) -      1.932M in   5.039982s
+#   from vector []    356.168k (± 2.6%) i/s    (2.81 μs/i) -      1.791M in   5.032325s
+#  from vector new    897.485k (± 4.3%) i/s    (1.11 μs/i) -      4.543M in   5.072670s
+#               -@    443.206k (± 5.1%) i/s    (2.26 μs/i) -      2.251M in   5.095046s
+#              * 3    487.009k (± 5.2%) i/s    (2.05 μs/i) -      2.464M in   5.077360s
+#      various (+)    234.189k (± 2.3%) i/s    (4.27 μs/i) -      1.172M in   5.008158s

--- a/bin/console
+++ b/bin/console
@@ -7,6 +7,9 @@ require "bundler/setup"
 # Supporting libraries.
 require "bigdecimal/util"
 
+require "benchmark"
+require "benchmark/ips"
+
 # This gem.
 require "vector_number"
 
@@ -17,6 +20,7 @@ Va = VectorNumber["a"]
 Vs = VectorNumber[:s]
 Vpi = VectorNumber[:pi] * Math::PI
 Vopt = VectorNumber[8, mult: :invisible]
+V = ((V1 * 3.3) + (Va * 4.5) - Vs)
 
 require "irb"
 IRB.start(__FILE__)

--- a/lib/vector_number.rb
+++ b/lib/vector_number.rb
@@ -173,10 +173,12 @@ class VectorNumber
   #
   # @since 0.1.0
   def initialize_from(values)
+    @data = values.to_h and return if values.is_a?(VectorNumber)
+
     @data = Hash.new(0)
 
     case values
-    when VectorNumber, Hash
+    when Hash
       add_vector_to_data(values)
     when Array
       values.each { |value| add_value_to_data(value) }

--- a/lib/vector_number.rb
+++ b/lib/vector_number.rb
@@ -253,7 +253,7 @@ class VectorNumber
       case values
       in VectorNumber
         merge_options(values.options, options)
-      in [*, VectorNumber => vector, *]
+      in Array[*, VectorNumber => vector, *]
         merge_options(vector.options, options)
       else
         merge_options(DEFAULT_OPTIONS, options)

--- a/lib/vector_number.rb
+++ b/lib/vector_number.rb
@@ -176,7 +176,6 @@ class VectorNumber
     @data = values.to_h and return if values.is_a?(VectorNumber)
 
     @data = Hash.new(0)
-
     case values
     when Array
       values.each { |value| add_value_to_data(value) }
@@ -251,32 +250,27 @@ class VectorNumber
   # @since 0.1.0
   def save_options(options, values:)
     @options =
-      case [options, values]
-      in [{} | nil, VectorNumber]
-        values.options
-      in [{} | nil, [*, VectorNumber => vector, *]]
-        vector.options
-      in Hash, VectorNumber
+      case values
+      in VectorNumber
         merge_options(values.options, options)
-      in Hash, [*, VectorNumber => vector, *]
+      in [*, VectorNumber => vector, *]
         merge_options(vector.options, options)
-      in Hash, _ unless options.empty?
-        merge_options(default_options, options)
       else
-        default_options
+        merge_options(DEFAULT_OPTIONS, options)
       end
   end
 
   # @param base_options [Hash{Symbol => Object}]
-  # @param added_options [Hash{Symbol => Object}]
+  # @param added_options [Hash{Symbol => Object}, nil]
   # @return [Hash{Symbol => Object}]
   #
   # @since 0.3.0
   def merge_options(base_options, added_options)
+    return base_options if !added_options || added_options.empty?
     # Optimization for the common case of passing options through #new.
     return base_options if added_options.equal?(base_options)
 
-    base_options.merge(added_options).slice(*known_options)
+    base_options.merge(added_options).slice(*KNOWN_OPTIONS)
   end
 
   # Compact coefficients, calculate size and freeze data.
@@ -287,15 +281,5 @@ class VectorNumber
     @data.delete_if { |_u, c| c.zero? }
     @data.freeze
     @size = @data.size
-  end
-
-  # @since 0.2.0
-  def default_options
-    DEFAULT_OPTIONS
-  end
-
-  # @since 0.2.0
-  def known_options
-    KNOWN_OPTIONS
   end
 end

--- a/lib/vector_number.rb
+++ b/lib/vector_number.rb
@@ -97,9 +97,9 @@ class VectorNumber
   #   VectorNumber.new(["a", "b", "c", 3], &:-@) # => (-1⋅'a' - 1⋅'b' - 1⋅'c' - 3)
   #   VectorNumber.new(["a", "b", "c", 3], &:digits) # RangeError
   #
-  # @param values [Array, Hash{Object => Integer, Float, Rational, BigDecimal}, VectorNumber]
+  # @param values [Array, VectorNumber, Hash{Object => Integer, Float, Rational, BigDecimal}, nil]
   #   values for this number, hashes are treated like plain vector numbers
-  # @param options [Hash{Symbol => Object}]
+  # @param options [Hash{Symbol => Object}, nil]
   #   options for this number, if +values+ is a VectorNumber or contains it,
   #   these will be merged with options from its +options+
   # @option options [Symbol, String] :mult
@@ -178,12 +178,14 @@ class VectorNumber
     @data = Hash.new(0)
 
     case values
-    when Hash
-      add_vector_to_data(values)
     when Array
       values.each { |value| add_value_to_data(value) }
+    when Hash
+      add_vector_to_data(values)
+    when nil
+      # Do nothing, as there are no values.
     else
-      # Don't add anything.
+      raise ArgumentError, "unsupported type for values: #{values.class}"
     end
   end
 

--- a/lib/vector_number.rb
+++ b/lib/vector_number.rb
@@ -37,7 +37,7 @@ class VectorNumber
   # Get a unit for +n+th numeric dimension, where 1 is real, 2 is imaginary.
   #
   # @since 0.2.0
-  UNIT = ->(n) { (n - 1).i }.freeze
+  UNIT = ->(n) { n }.freeze
   # Constant for real unit.
   #
   # @since 0.2.0

--- a/lib/vector_number.rb
+++ b/lib/vector_number.rb
@@ -206,7 +206,9 @@ class VectorNumber
   # @since 0.1.0
   def add_numeric_value_to_data(value)
     @data[R] += value.real
-    @data[I] += value.imaginary
+    # Most numbers will be real, and this extra condition appreciably speeds up addition,
+    # while having no noticeable impact on complex numbers.
+    @data[I] += value.imaginary unless value.real?
   end
 
   # @param vector [VectorNumber, Hash{Object => Integer, Float, Rational, BigDecimal}]

--- a/lib/vector_number/enumerating.rb
+++ b/lib/vector_number/enumerating.rb
@@ -21,7 +21,7 @@ class VectorNumber
     #   units # => ["a", "b"]
     # @example Enumerator
     #   v.each.size # => 3
-    #   (v.each + [["d", 0]]).map(&:first) # => ["a", "b", (0+0i), "d"]
+    #   (v.each + [["d", 0]]).map(&:first) # => ["a", "b", 1, "d"]
     #   v.each_pair.peek # => ["a", 1]
     #
     # @overload each
@@ -49,7 +49,7 @@ class VectorNumber
     # Get a list of units with non-zero coefficients.
     #
     # @example
-    #   VectorNumber["a", "b", 6].units # => ["a", "b", (0+0i)]
+    #   VectorNumber["a", "b", 6].units # => ["a", "b", 1]
     #   VectorNumber.new.keys # => []
     #
     # @return [Array<Object>]
@@ -79,7 +79,7 @@ class VectorNumber
     # Returned hash has a default value of 0.
     #
     # @example
-    #   VectorNumber["a", "b", 6].to_h # => {"a"=>1, "b"=>1, (0+0i)=>6}
+    #   VectorNumber["a", "b", 6].to_h # => {"a"=>1, "b"=>1, 1=>6}
     #   VectorNumber["a", "b", 6].to_h["c"] # => 0
     #
     # @return [Hash{Object => Integer, Float, Rational, BigDecimal}]

--- a/spec/vector_number/enumerating_spec.rb
+++ b/spec/vector_number/enumerating_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe VectorNumber::Enumerating do
       end
 
       include_examples "yields values", for_number: :zero_number, values: []
-      include_examples "yields values", for_number: :real_number, values: [[0.i, 1.5r]]
+      include_examples "yields values", for_number: :real_number, values: [[1, 1.5r]]
       include_examples "yields values", for_number: :composite_number,
-                                        values: [["y", 1], [:a, 1], [0.i, 5]]
+                                        values: [["y", 1], [:a, 1], [1, 5]]
     end
   end
 
@@ -65,8 +65,8 @@ RSpec.describe VectorNumber::Enumerating do
     end
 
     include_examples "returns units", for_number: :zero_number, values: []
-    include_examples "returns units", for_number: :real_number, values: [0.i]
-    include_examples "returns units", for_number: :composite_number, values: [0.i, "y", :a]
+    include_examples "returns units", for_number: :real_number, values: [1]
+    include_examples "returns units", for_number: :composite_number, values: [1, "y", :a]
   end
 
   include_examples "has an alias", :keys, :units
@@ -100,7 +100,7 @@ RSpec.describe VectorNumber::Enumerating do
     context "without a block" do
       it "returns plain vector representation without calling #each" do
         # Can't actually test for not calling #each, as objects are frozen and can't be mocked.
-        expect(hash).to eq(0.i => 5, "y" => 1, :a => 1)
+        expect(hash).to eq(1 => 5, "y" => 1, :a => 1)
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe VectorNumber::Enumerating do
       let(:block) { ->(u, v) { [u, u.is_a?(Numeric) ? v : v * 0.5] } }
 
       it "returns transformed plain vector representation" do
-        expect(hash).to eq(0.i => 5, "y" => 0.5, :a => 0.5)
+        expect(hash).to eq(1 => 5, "y" => 0.5, :a => 0.5)
       end
     end
   end

--- a/spec/vector_number/new_spec.rb
+++ b/spec/vector_number/new_spec.rb
@@ -162,4 +162,12 @@ RSpec.describe VectorNumber, ".new", :aggregate_failures do
       end
     end
   end
+
+  context "when initializing with unsupported type" do
+    let(:value) { Set.new(1, 2, 3) }
+
+    it "raises ArgumentError" do
+      expect { new_number }.to raise_error ArgumentError
+    end
+  end
 end

--- a/spec/vector_number/new_spec.rb
+++ b/spec/vector_number/new_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe VectorNumber, ".new", :aggregate_failures do
   end
 
   context "when initializing with unsupported type" do
-    let(:value) { Set.new(1, 2, 3) }
+    let(:value) { Object.new }
 
     it "raises ArgumentError" do
       expect { new_number }.to raise_error ArgumentError

--- a/spec/vector_number/new_spec.rb
+++ b/spec/vector_number/new_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe VectorNumber, ".new", :aggregate_failures do
     it "creates a new VectorNumber with default options" do
       expect(new_number).to be_a described_class
       expect(new_number).to be_frozen
-      expect(new_number.to_a).to contain_exactly [0.i, 1.75r], [1.i, 4.5r], [:a, 1], ["a", 2]
+      expect(new_number.to_a).to contain_exactly [1, 1.75r], [2, 4.5r], [:a, 1], ["a", 2]
       expect(new_number.options).to eq described_class::DEFAULT_OPTIONS
     end
 
@@ -105,14 +105,14 @@ RSpec.describe VectorNumber, ".new", :aggregate_failures do
 
     it "applies transformation before compaction" do
       expect(new_number.size).to eq 3
-      expect(new_number).to contain_exactly [0.i, 1.5r], [1.i, 1], ["s", 2]
+      expect(new_number).to contain_exactly [1, 1.5r], [2, 1], ["s", 2]
     end
 
     context "when transformation returns real vector number" do
       let(:block) { ->(v) { num(v + 1) } }
 
       it "works exactly the same as with a normal real number" do
-        expect(new_number).to contain_exactly [0.i, 1.5r], [1.i, 1], ["s", 2]
+        expect(new_number).to contain_exactly [1, 1.5r], [2, 1], ["s", 2]
       end
     end
 

--- a/spec/vector_number_spec.rb
+++ b/spec/vector_number_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe VectorNumber, :aggregate_failures do
 
     it "creates a new VectorNumber" do
       expect(number).to be_a described_class
-      expect(number.to_a).to contain_exactly [0.i, 5], ["a", 1]
+      expect(number.to_a).to contain_exactly [1, 5], ["a", 1]
       expect(number).to be_frozen
     end
 


### PR DESCRIPTION
- Reduce number of cases for option handling when there is no VectorNumber to take options from.
- Change units for numeric dimensions to speed up Hash access.
- Stop adding a single vector, duplicate its data directly, making mutation copying faster.
---
Benchmark:
```ruby
V = VectorNumber[3.3] + (4.5 * VectorNumber["a"]) - VectorNumber[:s]

Benchmark.ips do |ips|
  ips.report("real") { VectorNumber[1_345.34, -123.45, Complex(1, 0), 123.45r] }
  ips.report("real-real") { VectorNumber[1_345.34, -123.45, 1, 123.45r] }
  ips.report("complex") { VectorNumber[1_345.34i, Complex(12, -4556.2), Complex(0, 123.45), 15r] }
  ips.report("string/symbol") { VectorNumber["asdf", "sdnhsdughdfghkdfg", :asdsafsdf, "asdf"] }
  ips.report("from vector []") { VectorNumber[V] }
  ips.report("from vector new") { VectorNumber.new(V) }
  ips.report("-@") { -V }
  ips.report("* 3") { V * 3 }
  ips.report("various (+)") { VectorNumber[Complex(12, -4556.2), V, "asdf", :asdsafsdf, "asdf"] }
end
```

Baseline:
```
Calculating -------------------------------------
                real    120.248k (± 6.7%) i/s    (8.32 μs/i) -    600.984k in   5.026862s
           real-real    123.672k (± 6.2%) i/s    (8.09 μs/i) -    616.224k in   5.006814s
             complex    118.893k (± 4.8%) i/s    (8.41 μs/i) -    597.450k in   5.039148s
       string/symbol    273.629k (± 6.4%) i/s    (3.65 μs/i) -      1.373M in   5.042627s
      from vector []    289.128k (± 6.4%) i/s    (3.46 μs/i) -      1.463M in   5.085560s
     from vector new    379.761k (± 6.6%) i/s    (2.63 μs/i) -      1.891M in   5.010302s
                  -@    235.569k (± 6.8%) i/s    (4.25 μs/i) -      1.192M in   5.088220s
                 * 3    248.626k (± 6.2%) i/s    (4.02 μs/i) -      1.260M in   5.097549s
         various (+)    165.008k (± 4.9%) i/s    (6.06 μs/i) -    831.630k in   5.054346s
```

- Adding numbers is suprisingly slow.
- Copying a single vector with `new` is pretty fast.