### PR TITLE
Fix version links in Changelog, add custom tasks for future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Next]
+
+Small update to fix Changelog.
+
+[Compare v0.4.0...main](https://github.com/trinistr/vector_number/compare/v0.4.0...main)
+
 ## [v0.4.0] — 2025-07-07
 
 **Changed**
@@ -15,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimize various initialization paths. It is now 1.5-2.5 times faster, depending on arguments.
 - [🚀 CI] Disable JRuby testing on CI.
 
-[Compare v0.3.1...main](https://github.com/trinistr/vector_number/compare/v0.3.1...main)
+[Compare v0.3.1...v0.4.0](https://github.com/trinistr/vector_number/compare/v0.3.1...v0.4.0)
 
 ## [v0.3.1] — 2025-06-21
 
@@ -149,6 +154,7 @@ README was updated to reflect this change.
 - Initial work.
 
 [Next]: https://github.com/trinistr/vector_number/tree/main
+[v0.4.0]: https://github.com/trinistr/vector_number/tree/v0.4.0
 [v0.3.1]: https://github.com/trinistr/vector_number/tree/v0.3.1
 [v0.3.0]: https://github.com/trinistr/vector_number/tree/v0.3.0
 [v0.2.6]: https://github.com/trinistr/vector_number/tree/v0.2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+[Compare v0.4.1...main](https://github.com/trinistr/vector_number/compare/v0.4.1...main)
+
+
+## [v0.4.1] — 2025-07-07
+
 Small update to fix Changelog.
 
-[Compare v0.4.0...main](https://github.com/trinistr/vector_number/compare/v0.4.0...main)
+[Compare v0.4.0...v0.4.1](https://github.com/trinistr/vector_number/compare/v0.4.0...v0.4.1)
 
 ## [v0.4.0] — 2025-07-07
 
@@ -154,6 +159,7 @@ README was updated to reflect this change.
 - Initial work.
 
 [Next]: https://github.com/trinistr/vector_number/tree/main
+[v0.4.1]: https://github.com/trinistr/vector_number/tree/v0.4.1
 [v0.4.0]: https://github.com/trinistr/vector_number/tree/v0.4.0
 [v0.3.1]: https://github.com/trinistr/vector_number/tree/v0.3.1
 [v0.3.0]: https://github.com/trinistr/vector_number/tree/v0.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vector_number (0.4.0)
+    vector_number (0.4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@
 require "English"
 require "bundler/gem_tasks"
 
+task default: %i[spec rubocop rbs]
+
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
@@ -14,14 +16,6 @@ rescue LoadError
   task :rubocop do
     puts "RuboCop is not available, linting will not be done!"
   end
-end
-
-begin
-  require "bump/tasks"
-  Bump.changelog = true
-  Bump.tag_by_default = true
-rescue LoadError
-  # skip loading bump (only available in development)
 end
 
 desc "Validate signatures with RBS"
@@ -49,4 +43,61 @@ task :docs do
   exit $CHILD_STATUS.exitstatus || 1 unless status
 end
 
-task default: %i[spec rubocop rbs]
+namespace :version do
+  desc "Bump major version"
+  task :major do
+    Rake::Task["version:_update_version"].invoke("major")
+  end
+
+  desc "Bump minor version"
+  task :minor do
+    Rake::Task["version:_update_version"].invoke("minor")
+  end
+
+  desc "Bump patch version"
+  task :patch do
+    Rake::Task["version:_update_version"].invoke("patch")
+  end
+
+  task :_update_version, [:bump] do |_task, args|
+    require "bump"
+    Bump::Bump.run(args[:bump], commit: false, changelog: true)
+    
+    name = Dir["*.gemspec"].first.then { File.readlines(_1).grep(/spec\.name = "\w+"/).first.match(/"(\w+)"/)[1] }
+    new_version = Bump::Bump.current
+    Rake::Task["version:_update_changelog"].invoke(name, new_version)
+    Rake::Task["version:_commit_and_tag"].invoke(name, new_version)
+  end
+
+  task :_update_changelog, [:name, :new_version] do |_task, args|
+    name = args[:name]
+    new_version = args[:new_version]
+
+    changelog = File.read("CHANGELOG.md").split(/(^##+.*)/)
+    # Change previous comparison link
+    prev_index = changelog.index { _1.match?(/^## \[v#{new_version}\]/) }
+    changelog[prev_index + 1].gsub!("...main", "...v#{new_version}")
+    # Add new comparison link
+    next_index = changelog.index { _1.match?(/^## \[Next\]/) }
+    changelog[next_index] <<
+      "\n\n[Compare v#{new_version}...main](https://github.com/trinistr/#{name}/compare/v#{new_version}...main)\n\n"
+    # Add a version link
+    changelog.last.sub!(
+      /\[Next\]: .+/,
+      "\\0\n[v#{new_version}]: https://github.com/trinistr/#{name}/tree/v#{new_version}"
+    )
+
+    File.write("CHANGELOG.md", changelog.join)
+  end
+
+  task :_commit_and_tag, [:name, :new_version] do |_task, args|
+    name = args[:name]
+    new_version = args[:new_version]
+
+    %W[CHANGELOG.md Gemfile.lock lib/#{name}/version.rb].each do |f|
+      system("git", "add", "--update", f)
+    end
+    system("git", "commit", "-m", "v#{new_version}")
+    system("git", "tag", "-s", "-m", "v#{new_version}", "v#{new_version}")
+  end
+end

--- a/lib/vector_number/version.rb
+++ b/lib/vector_number/version.rb
@@ -2,5 +2,5 @@
 
 class VectorNumber
   # @return [String]
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
I again forgot to add version links in Changelog. This keeps happening and will probably happen again. So, I replaced Bump tasks with custom tasks that do more.