### PR TITLE
Refactor handling of units for numeric dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Next]
 
 **Added**
-- Block parameter in `#to_s`, allowing to fully customize string representation.
+- Block parameter in `#to_s`, allowing to customize string conversion.
+- `VectorNumber::SpecialUnit` class for representing special numerical units. It mostly exists to provide its `#to_s` method.
+  - [🍄 BREAKING] `R` and `I` constants are now instances of `SpecialUnit` class.
+- `.numeric_unit?` method and `NUMERIC_UNITS` constant for checking units.
 
-**Changed**
+**Removed**
 - [🍄 BREAKING] Removed options in their entirety. The only way to specify multiplication symbol is in call to `#to_s`.
   - Constructors' signatures now include `**nil` to prevent mistakes.
+- `UNIT` constant. Use `NUMERIC_UNITS` instead (though you shouldn't anyway).
+
+**Changed**
 - `VectorNumber#to_s` now calls `#inspect` on Strings instead of just using `String#to_s`. This prevents issues with embedded quotation marks.
   - As a a side effect, String units are now surrounded by double quotes, not single.
 
@@ -27,7 +33,7 @@ This update changes code structure, aligning it more closely with the intended d
 - Update documentation. Add a listing of all methods and general information to class's documentation. Group methods by type.
 
 **Fixed**
-- `eql?` now correctly tests equality using `eql?`, not `==`. `v1.eql?(v2) -> v1.hash == v2.hash` should now always hold.
+- `#eql?` now correctly tests equality using `eql?`, not `==`. `v1.eql?(v2) -> v1.hash == v2.hash` should now always hold.
 
 [Compare v0.4.3...v0.5.0](https://github.com/trinistr/vector_number/compare/v0.4.3...v0.5.0)
 
@@ -165,15 +171,15 @@ README was updated to reflect this change.
 - Add `#*` and `#/` for working with real numbers.
 - Add `#fdiv`, `#truncate`, `#nonnumeric?` and `#integer?`.
 
+**Removed**
+- Remove `#to_str`, as VectorNumber is not a String-like object.
+  - Due to this, `Kernel.BigDecimal` no longer works without refinements.
+
 **Changed**
 - Allow to use fully real VectorNumbers as real numbers.
 
 **Fixed**
 - Fix reversed result in refined `#<=>`.
-
-**Removed**
-- Remove `#to_str`, as VectorNumber is not a String-like object.
-- Due to the above, `Kernel.BigDecimal` no longer works without refinements.
 
 [Compare v0.2.0...v0.2.1](https://github.com/trinistr/vector_number/compare/v0.2.0...v0.2.1)
 

--- a/lib/vector_number.rb
+++ b/lib/vector_number.rb
@@ -73,11 +73,14 @@
 # - {#to_h}: convert to Hash
 #
 # **Miscellaneous** **methods**
-# - {#size}: number of non-zero coefficients
-# - {#dup}/{#+}: return self
-# - {#clone}: return self
+# - {.numeric_unit?}: check if a unit represents a numeric dimension
+# - {#size}: number of non-zero dimensions
 # - {#to_s}: return string representation suitable for printing
 # - {#inspect}: return string representation suitable for display
+# - {#dup}/{#+}: return self
+# - {#clone}: return self
+#
+# @since 0.1.0
 class VectorNumber
   require_relative "vector_number/comparing"
   require_relative "vector_number/converting"
@@ -88,18 +91,24 @@ class VectorNumber
   require_relative "vector_number/stringifying"
   require_relative "vector_number/version"
 
-  # Get a unit for +n+th numeric dimension, where 1 is real, 2 is imaginary.
+  require_relative "vector_number/special_unit"
+
+  # List of special numeric unit constants.
   #
-  # @since 0.2.0
-  UNIT = ->(n) { n }.freeze
-  # Constant for real unit.
+  # @since <<next>>
+  NUMERIC_UNITS = [SpecialUnit.new("1", "").freeze, SpecialUnit.new("i", "i").freeze].freeze
+  # Constant for real unit (1).
   #
-  # @since 0.2.0
-  R = UNIT[1]
-  # Constant for imaginary unit.
+  # Its string representation is an empty string.
   #
-  # @since 0.1.0
-  I = UNIT[2]
+  # @since <<next>>
+  R = NUMERIC_UNITS[0]
+  # Constant for imaginary unit (i).
+  #
+  # Its string representation is "i".
+  #
+  # @since <<next>>
+  I = NUMERIC_UNITS[1]
 
   # @group Creation
   # Create new VectorNumber from a list of values.
@@ -118,6 +127,22 @@ class VectorNumber
     new(values)
   end
   # @endgroup
+
+  # Check if an object is a unit representing a numeric dimension
+  # (real or imaginary unit).
+  #
+  # @example
+  #   VectorNumber.numeric_unit?(VectorNumber::R) # => true
+  #   VectorNumber.numeric_unit?(VectorNumber::I) # => true
+  #   VectorNumber.numeric_unit?(:i) # => false
+  #
+  # @param unit [Object]
+  # @return [Boolean]
+  #
+  # @since 0.6.0
+  def self.numeric_unit?(unit)
+    NUMERIC_UNITS.include?(unit)
+  end
 
   # Number of non-zero dimensions.
   #

--- a/lib/vector_number/querying.rb
+++ b/lib/vector_number/querying.rb
@@ -16,7 +16,7 @@ class VectorNumber
   # @param dimensions [Integer] number of dimensions to consider "numeric"
   #   - 0 — zero
   #   - 1 — real number
-  #   - 2 — complex number, etc.
+  #   - 2 — complex number
   # @return [Boolean]
   # @raise [ArgumentError] if +dimensions+ is negative
   #
@@ -24,7 +24,8 @@ class VectorNumber
   def numeric?(dimensions = 2)
     raise ArgumentError, "`dimensions` must be non-negative" unless dimensions >= 0
 
-    size <= dimensions && (1..dimensions).count { @data[UNIT[_1]].nonzero? } == size
+    size <= dimensions &&
+      (0...dimensions).count { (unit = NUMERIC_UNITS[_1]) && @data[unit].nonzero? } == size
   end
 
   # Whether this VectorNumber contains any non-numeric parts.

--- a/lib/vector_number/special_unit.rb
+++ b/lib/vector_number/special_unit.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class VectorNumber
+  # Class for representing special units.
+  #
+  # The public API consists of:
+  # - +#==+/+#eql?+/+#equal?+ (from +Object+)
+  # - +#hash+ (from +Object+)
+  # - {#to_s}
+  # - {#inspect}
+  #
+  # @since <<next>>
+  class SpecialUnit
+    # @api private
+    # @param unit [#to_s] name for {#inspect}
+    # @param text [String] text for {#to_s}
+    def initialize(unit, text)
+      @unit = unit
+      @text = text
+    end
+
+    # Get predefined string representation of the unit.
+    #
+    # @return [String]
+    def to_s
+      @text
+    end
+
+    # Get string representation of the unit for debugging.
+    #
+    # @return [String]
+    def inspect
+      "unit/#{@unit}"
+    end
+  end
+end

--- a/lib/vector_number/stringifying.rb
+++ b/lib/vector_number/stringifying.rb
@@ -19,9 +19,10 @@ class VectorNumber
 
   # Return string representation of the vector.
   #
-  # An optional block can be used to provide customized substrings
+  # An optional block can be supplied to provide customized substrings
   # for each unit and coefficient pair.
   # Care needs to be taken in handling +VectorNumber::R+ and +VectorNumber::I+ units.
+  # {.numeric_unit?} can be used to check if a particular unit needs special handling.
   #
   # @example
   #   VectorNumber[5, "s"].to_s # => "5 + 1⋅\"s\""
@@ -82,7 +83,7 @@ class VectorNumber
     result = +""
     each_with_index do |(unit, coefficient), index|
       if block_given?
-        result << (yield unit, coefficient, index, operator)
+        result << (yield unit, coefficient, index, operator).to_s
       else
         if index.zero?
           result << "-" if coefficient.negative?
@@ -100,11 +101,8 @@ class VectorNumber
   # @param operator [String]
   # @return [String]
   def value_to_s(unit, coefficient, operator)
-    case unit
-    when R
-      coefficient.to_s
-    when I
-      "#{coefficient}i"
+    if NUMERIC_UNITS.include?(unit)
+      "#{coefficient}#{unit}"
     else
       unit = unit.inspect if unit.is_a?(String)
       "#{coefficient}#{operator}#{unit}"

--- a/sig/vector_number.rbs
+++ b/sig/vector_number.rbs
@@ -18,13 +18,15 @@ class VectorNumber
 
   VERSION: String
 
-  UNIT: ^(Integer) -> Complex
-  R: Complex
-  I: Complex
+  NUMERIC_UNITS: list[SpecialUnit]
+  R: SpecialUnit
+  I: SpecialUnit
 
   # ---- Public methods ----
 
   def self.[]: (*unit_type values) -> instance
+
+  def self.numeric_unit?: (unit_type unit) -> bool
 
   def size: -> Integer
 
@@ -224,5 +226,16 @@ class VectorNumber
       def BigDecimal: (untyped value, exception: bool) -> BigDecimal?
                     | (untyped value, Integer ndigits, exception: bool) -> BigDecimal?
     end
+  end
+end
+
+class VectorNumber
+  # Class for representing special numerical units.
+  class SpecialUnit
+    def initialize: (Object unit, String text) -> void
+
+    def to_s: () -> String
+    
+    def inspect: () -> String
   end
 end

--- a/spec/vector_number/enumerating_spec.rb
+++ b/spec/vector_number/enumerating_spec.rb
@@ -43,9 +43,11 @@ RSpec.describe VectorNumber do
       end
 
       include_examples "yields values", for_number: :zero_number, values: []
-      include_examples "yields values", for_number: :real_number, values: [[1, 1.5r]]
-      include_examples "yields values", for_number: :composite_number,
-                                        values: [["y", 1], [:a, 1], [1, 5]]
+      include_examples "yields values",
+                       for_number: :real_number, values: [[described_class::R, 1.5r]]
+      include_examples "yields values",
+                       for_number: :composite_number,
+                       values: [["y", 1], [:a, 1], [described_class::R, 5]]
     end
   end
 
@@ -65,8 +67,9 @@ RSpec.describe VectorNumber do
     end
 
     include_examples "returns units", for_number: :zero_number, values: []
-    include_examples "returns units", for_number: :real_number, values: [1]
-    include_examples "returns units", for_number: :composite_number, values: [1, "y", :a]
+    include_examples "returns units", for_number: :real_number, values: [described_class::R]
+    include_examples "returns units",
+                     for_number: :composite_number, values: [described_class::R, "y", :a]
   end
 
   include_examples "has an alias", :keys, :units
@@ -100,15 +103,15 @@ RSpec.describe VectorNumber do
     context "without a block" do
       it "returns plain vector representation without calling #each" do
         # Can't actually test for not calling #each, as objects are frozen and can't be mocked.
-        expect(hash).to eq(1 => 5, "y" => 1, :a => 1)
+        expect(hash).to eq(described_class::R => 5, "y" => 1, :a => 1)
       end
     end
 
     context "with a block" do
-      let(:block) { ->(u, v) { [u, u.is_a?(Numeric) ? v : v * 0.5] } }
+      let(:block) { ->(u, v) { [u, described_class.numeric_unit?(u) ? v : v * 0.5] } }
 
       it "returns transformed plain vector representation" do
-        expect(hash).to eq(1 => 5, "y" => 0.5, :a => 0.5)
+        expect(hash).to eq(described_class::R => 5, "y" => 0.5, :a => 0.5)
       end
     end
   end

--- a/spec/vector_number/new_spec.rb
+++ b/spec/vector_number/new_spec.rb
@@ -85,14 +85,18 @@ RSpec.describe VectorNumber, ".new", :aggregate_failures do
 
     it "applies transformation before compaction" do
       expect(new_number.size).to eq 3
-      expect(new_number).to contain_exactly [1, 1.5r], [2, 1], ["s", 2]
+      expect(new_number).to contain_exactly(
+        [described_class::R, 1.5r], [described_class::I, 1], ["s", 2]
+      )
     end
 
     context "when transformation returns real vector number" do
       let(:block) { ->(v) { num(v + 1) } }
 
       it "works exactly the same as with a normal real number" do
-        expect(new_number).to contain_exactly [1, 1.5r], [2, 1], ["s", 2]
+        expect(new_number).to contain_exactly(
+          [described_class::R, 1.5r], [described_class::I, 1], ["s", 2]
+        )
       end
     end
 

--- a/spec/vector_number/querying_spec.rb
+++ b/spec/vector_number/querying_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe VectorNumber, :aggregate_failures do
 
   describe "#numeric?" do
     context "when dimensions = 0" do
-      it "considers numbers which contain no parts to be numeric" do
+      it "considers numbers which contain no parts (0) to be numeric" do
         expect(null_number.numeric?(0)).to be true
         expect(zero_number.numeric?(0)).to be true
         expect(real_number.numeric?(0)).to be false
@@ -19,7 +19,7 @@ RSpec.describe VectorNumber, :aggregate_failures do
     end
 
     context "when dimensions = 1" do
-      it "considers numbers which contain only real part to be numeric" do
+      it "considers numbers which contain only real part or 0 to be numeric" do
         expect(null_number.numeric?(1)).to be true
         expect(zero_number.numeric?(1)).to be true
         expect(real_number.numeric?(1)).to be true
@@ -46,6 +46,10 @@ RSpec.describe VectorNumber, :aggregate_failures do
         expect(imaginary_number.numeric?(3)).to be true
         expect(composite_number.numeric?(3)).to be false
       end
+
+      it "does not consider nil to be a numeric dimension" do
+        expect(num(nil).numeric?(3)).to be false
+      end
     end
 
     context "when dimensions < 0" do
@@ -57,7 +61,7 @@ RSpec.describe VectorNumber, :aggregate_failures do
 
   describe "#nonnumeric?" do
     context "when dimensions = 0" do
-      it "considers numbers which contain any parts to be non-numeric" do
+      it "considers numbers which contain any parts (non-0) to be non-numeric" do
         expect(null_number.nonnumeric?(0)).to be false
         expect(zero_number.nonnumeric?(0)).to be false
         expect(real_number.nonnumeric?(0)).to be true
@@ -77,7 +81,7 @@ RSpec.describe VectorNumber, :aggregate_failures do
     end
 
     context "when dimensions = 2" do
-      it "considers number which contain non-numeric units to be non-numeric" do
+      it "considers numbers which contain non-numeric units to be non-numeric" do
         expect(null_number.nonnumeric?(2)).to be false
         expect(zero_number.nonnumeric?(2)).to be false
         expect(real_number.nonnumeric?(2)).to be false
@@ -87,12 +91,16 @@ RSpec.describe VectorNumber, :aggregate_failures do
     end
 
     context "when dimensions > 2" do
-      it "considers number which contain non-numeric units to be non-numeric" do
+      it "considers numbers which contain non-numeric units to be non-numeric" do
         expect(null_number.nonnumeric?(3)).to be false
         expect(zero_number.nonnumeric?(3)).to be false
         expect(real_number.nonnumeric?(3)).to be false
         expect(imaginary_number.nonnumeric?(3)).to be false
         expect(composite_number.nonnumeric?(3)).to be true
+      end
+
+      it "considers nil to be a non-numeric dimension" do
+        expect(num(nil).nonnumeric?(3)).to be true
       end
     end
 

--- a/spec/vector_number/special_unit_spec.rb
+++ b/spec/vector_number/special_unit_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe VectorNumber::SpecialUnit do
+  describe ".new" do
+    it "creates a new special unit" do
+      unit = described_class.new(1, "m")
+      expect(unit).to be_a described_class
+    end
+  end
+
+  describe "#to_s" do
+    it "returns predefined string" do
+      expect(described_class.new(1, "m").to_s).to eq "m"
+      expect(described_class.new(10, "qwe").to_s).to eq "qwe"
+    end
+  end
+
+  describe "#inspect" do
+    it "returns string representation for debugging" do
+      expect(described_class.new(13, "asd").inspect).to eq "unit/13"
+      expect(described_class.new(:i, "asd").inspect).to eq "unit/i"
+    end
+  end
+
+  describe "#==" do
+    it "returns true for the same unit" do
+      unit = described_class.new(1, "m")
+      expect(unit).to eq unit # rubocop:disable RSpec/IdenticalEqualityAssertion
+    end
+
+    it "returns false for different units" do
+      unit_1 = described_class.new(1, "m")
+      unit_2 = described_class.new(2, "m")
+      expect(unit_1).not_to eq unit_2
+    end
+
+    it "returns false for different object with same attributes" do
+      unit_1 = described_class.new(1, "m")
+      unit_2 = described_class.new(1, "m")
+      expect(unit_1).not_to eq unit_2
+    end
+  end
+end

--- a/spec/vector_number/stringifying_spec.rb
+++ b/spec/vector_number/stringifying_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe VectorNumber do
         let(:block) { proc { |unit, coefficient| "#{coefficient}#{unit}," } }
 
         it "uses the block to format each unit-coefficient pair" do
-          expect(string).to eq "1y,1a,-311,"
+          expect(string).to eq "1y,1a,-31,"
         end
       end
 
@@ -88,7 +88,7 @@ RSpec.describe VectorNumber do
         let(:block) { proc { |unit, coefficient, index| "#{index}:#{coefficient}#{unit}," } }
 
         it "allows to use index for extra formatting" do
-          expect(string).to eq "0:1y,1:1a,2:-311,"
+          expect(string).to eq "0:1y,1:1a,2:-31,"
         end
       end
 
@@ -98,15 +98,15 @@ RSpec.describe VectorNumber do
         end
 
         it "allows to use defined multiplication operator" do
-          expect(string).to eq "0:1⋅y,1:1⋅a,2:-31⋅1,"
+          expect(string).to eq "0:1⋅y,1:1⋅a,2:-31⋅,"
         end
 
         it "passes specified :mult operator to the block" do
           with_string = composite_number.to_s(mult: "#", &block)
-          expect(with_string).to eq "0:1#y,1:1#a,2:-31#1,"
+          expect(with_string).to eq "0:1#y,1:1#a,2:-31#,"
 
           with_symbol = composite_number.to_s(mult: :cross, &block)
-          expect(with_symbol).to eq "0:1×y,1:1×a,2:-31×1,"
+          expect(with_symbol).to eq "0:1×y,1:1×a,2:-31×,"
         end
       end
     end

--- a/spec/vector_number_spec.rb
+++ b/spec/vector_number_spec.rb
@@ -11,8 +11,20 @@ RSpec.describe VectorNumber, :aggregate_failures do
 
     it "creates a new VectorNumber" do
       expect(number).to be_a described_class
-      expect(number.to_a).to contain_exactly [1, 5], ["a", 1]
+      expect(number.to_a).to contain_exactly [described_class::R, 5], ["a", 1]
       expect(number).to be_frozen
+    end
+  end
+
+  describe ".numeric_unit?" do
+    it "returns true for special numeric units" do
+      expect(described_class.numeric_unit?(described_class::R)).to be true
+      expect(described_class.numeric_unit?(described_class::I)).to be true
+    end
+
+    it "returns false for regular units" do
+      expect(described_class.numeric_unit?(:a)).to be false
+      expect(described_class.numeric_unit?(1)).to be false
     end
   end
 


### PR DESCRIPTION
More for #28, continuing #30.
Previous iteration was awkward, as there was no way to easily check "is this unit a numeric dimension constant?", requiring at least two comparisons. Additionally, each time a custom mapping of unit to text would be needed.

Now handling of units can be simplified to
```ruby
"#{coefficient}#{operator unless VectorNumber.numeric_unit?(unit)}#{unit}"
```

- Add `SpecialUnit` class. Instances of it are basically unique descriptors.
- Add `.numeric_unit?` method to simplify checking units for users.
- Add NUMERIC_UNITS, remove UNIT.
- Consistently use constant units in tests, because otherwise they wouldn't work.
- Simplify `#to_s`, increasing performance.

Originally, `SpecialUnit` had "dimension" attribute and equality logic. However, that made benchmarks around 2 times slower. Thus in the end instances are unique, to use underlying object-equality semantics (which are hopefully implemented to be very fast).

Sadly, working with numbers is now slower anyway. However, it's still fast enough (even slowest benchmarks show <5 μs/iteration). And `#to_s` is actually faster now, because there is less logic.